### PR TITLE
fix: Better handling of out of order events

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,7 @@ linters:
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/elastic/go-libaudit
+    local-prefixes: github.com/SEKOIA-IO/go-libaudit
   gofumpt:
     extra-rules: true
   goheader:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Package documentation can be found on [GoDoc][godocs].
 Installation can be done with a normal `go get`:
 
 ```
-$ go get github.com/elastic/go-libaudit
+$ go get github.com/SEKOIA-IO/go-libaudit
 ```
 
 ### audit example
@@ -29,7 +29,7 @@ and outputs the data it receives to stdout. The system's `auditd` process
 should be stopped first.
 
 ```
-$ go install github.com/elastic/go-libaudit/cmd/audit@main
+$ go install github.com/SEKOIA-IO/go-libaudit/cmd/audit@main
 $ sudo $GOPATH/bin/audit -d
 ```
 
@@ -40,7 +40,7 @@ process or the output of the _audit_ example command. It combines related log
 messages that are a part of the same event.
 
 ```
-$ go install github.com/elastic/go-libaudit/cmd/auparse@main
+$ go install github.com/SEKOIA-IO/go-libaudit/cmd/auparse@main
 $ sudo cat /var/log/audit/audit.log | auparse
 ---
 type=CRED_ACQ msg=audit(1481077334.302:545): pid=1444 uid=0 auid=1000 ses=4 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=PAM:setcred grantors=pam_env,pam_unix acct="root" exe="/usr/bin/sudo" hostname=? addr=? terminal=/dev/pts/1 res=success'


### PR DESCRIPTION
In the current implementation we have some issues when events are received out of order.

If we receive 4 events in the following order: `1, 3, 2, 4` the `EventsLost` callback will be called 2 times:
* When we received `3` because `2` was not received yet
* When we received `4` because of the gap between `2` and `4` event if `3` was previously received

This PR adds a map to track the missing sequences with a timeout that, once reached will trigger the `EventsLost` callback.

When an event is received it is discarded from the missing events map.

The maps has a limited size so events might be removed before the timeout if the map is full.

This PR handles case where the sequence number rolls over: when it reaches the maximum of `uint32` it goes back to `0`.