### PR TITLE
ci: Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Cooldown applies only to version updates, not security updates
+    cooldown:
+      default-days: 14
+    groups:
+      # Group all version updates into a single PR; security updates remain ungrouped
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,11 +2,13 @@ name: golangci-lint
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   golangci:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Read .go-version file
         id: goversion
-        run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
+        run: echo "version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,18 +10,19 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Read .go-version file
         id: goversion
         run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        # golangci-lint-action v7+ requires golangci-lint v2; stay on v6.x while using v1.54.2
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: v1.54.2
           args: --timeout=5m


### PR DESCRIPTION
## Summary

- Configure Dependabot for GitHub Actions (weekly, 14-day cooldown, grouped version updates)
- Pin actions to commit SHAs (14-day minimum age)
- Pin `golangci-lint-action` to v6.5.2 (not v9) because v7+ only supports golangci-lint v2, and this repo uses v1.54.2
- Least-privilege `permissions` (deny-all at workflow level, minimal job-level grants)
- Fix actionlint findings
